### PR TITLE
[codex] Fix TypeScript 6 tsconfig warning

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  }
+  "extends": "@docusaurus/tsconfig"
 }


### PR DESCRIPTION
## Summary

- Remove deprecated `compilerOptions.baseUrl` from `tsconfig.json`.
- Avoid the TypeScript 6.0 deprecation failure without adding an ignore flag that current TypeScript rejects.

## Validation

- Ran `npm.cmd run typecheck` successfully.