### PR TITLE
Ignore TypeScript 6 deprecations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@docusaurus/tsconfig"
+  "extends": "@docusaurus/tsconfig",
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0"
+  }
 }


### PR DESCRIPTION
## Summary
- Add compilerOptions.ignoreDeprecations for TypeScript 6.0 in tsconfig.json

## Testing
- git diff --check -- tsconfig.json